### PR TITLE
Fix typo ("of" -> "off") in a few places

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,6 +1,6 @@
 # Handoff!
 
-Get your hand hand of that mouse!
+Get your hand hand off that mouse!
 
 ## Installation
 

--- a/handoff.el
+++ b/handoff.el
@@ -1,4 +1,4 @@
-;;; handoff.el --- Get your hand of that mouse, damn it!
+;;; handoff.el --- Get your hand off that mouse, damn it!
 
 ;; Copyright (C) 2015 Johan Andersson
 
@@ -56,14 +56,14 @@
   "Keymap for `handoff-mode'.")
 
 (defun handoff! ()
-  "Get your hand of that mouse, damn it!"
+  "Get your hand off that mouse, damn it!"
   (interactive)
   (let ((zone-programs handoff-zone-programs))
     (call-interactively 'zone)))
 
 ;;;###autoload
 (define-minor-mode handoff-mode
-  "Get your hand of that mouse, damn it!"
+  "Get your hand off that mouse, damn it!"
   :init-value nil
   :keymap handoff-mode-map)
 


### PR DESCRIPTION
Saw this on melpa, felt like changing it... I think you meant 'off' not 'of'. :pizza:
